### PR TITLE
Update .gitignore for local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ hs_err_pid*.log
 /.m2
 settings.xml
 .codenvy
+# ignore local copilot instructions
+.copilot-instructions.md


### PR DESCRIPTION
This PR adds .copilot-instructions.md to .gitignore to allow for local, user-specific Copilot instructions that won't be committed to the repository.